### PR TITLE
enhance: Use soft link for dotfiles and recover the removed lua install role

### DIFF
--- a/ansible-playbooks/roles/go/tasks/main.yml
+++ b/ansible-playbooks/roles/go/tasks/main.yml
@@ -1,6 +1,5 @@
 ---
   - name: Clean gvm files
-    become: true
     file:
       path: ~/.gvm
       state: absent

--- a/ansible-playbooks/roles/settings/tasks/main.yml
+++ b/ansible-playbooks/roles/settings/tasks/main.yml
@@ -8,7 +8,7 @@
     file:
       src: '~/github/zsh-tmux-setting/{{ item }}'
       dest: '~/{{ item }}'
-      state: hard
+      state: link
       force: yes
     loop:
       - '.p10k.zsh'
@@ -39,7 +39,7 @@
     file:
       src: '{{ item.src }}'
       dest: '{{ item.dest }}'
-      state: hard
+      state: link
       force: yes
     loop:
       - { src: '~/github/zsh-tmux-setting/lfcd.sh', dest: '~/.local/bin/lfcd.sh'}

--- a/ansible-playbooks/roles/tmux/tasks/main.yml
+++ b/ansible-playbooks/roles/tmux/tasks/main.yml
@@ -28,5 +28,5 @@
     file:
       src: ~/github/.tmux/.tmux.conf
       dest: ~/.tmux.conf
-      state: hard
+      state: link
 

--- a/ansible-playbooks/roles/tools/meta/main.yml
+++ b/ansible-playbooks/roles/tools/meta/main.yml
@@ -1,4 +1,5 @@
 ---
 dependencies:
   - role: git
+  - role: lua
   - role: go


### PR DESCRIPTION
# Description
- Use soft link for dotfiles to sync the change between the git repo and the dotfiles at the actual config path
- Recover the accidentally removed lua install role